### PR TITLE
query: ntoh

### DIFF
--- a/5_macro_definitions.ql
+++ b/5_macro_definitions.ql
@@ -1,2 +1,5 @@
+import cpp
 
-
+from Macro m
+where m.getName() = ["ntohs", "ntohl", "ntohll"]
+select m, "macros with name ntohs, ntohl or ntohll"


### PR DESCRIPTION
adds query for ntoh network macros